### PR TITLE
Fix compilation with external gdal library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,8 @@ if(NOT MSVC)
   #set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -Wall -Wextra --pedantic")
 endif()
 
+FIND_PACKAGE (Threads)
+
 # We need GDAL
 find_package(GDAL)
 if(NOT GDAL_FOUND)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,7 +1,11 @@
 # Ensure we have a unified GDAL: `GDALOpenEx` is only present after
 # unification.
 include(CheckLibraryExists)
-check_library_exists(gdal GDALOpenEx "gdal.h" HAVE_UNIFIED_GDAL)
+if (${GDAL_LIBRARY_DIR})
+  message("Searching GDAL library in provided ${GDAL_LIBRARY_DIR}")
+endif()
+
+check_library_exists(gdal GDALOpenEx ${GDAL_LIBRARY_DIR} HAVE_UNIFIED_GDAL)
 if(NOT MSVC AND NOT HAVE_UNIFIED_GDAL)
   message(FATAL_ERROR "The GDAL version must be one that implements RFC 46 (GDAL/OGR unification) i.e. >= 2.0.0")
 endif()

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,7 +1,7 @@
 # The tools are not shared libraries
 add_definitions(-DCPL_DISABLE_DLL)
 
-set(TOOL_TARGETS commander ctb)
+set(TOOL_TARGETS commander ctb  ${CMAKE_THREAD_LIBS_INIT})
 
 # Add the `ctb-tile` executable
 add_executable(ctb-tile ctb-tile.cpp)


### PR DESCRIPTION
Checking for libgdal2 was failing when the library was not in the
system library path. Additionally, the pthread library was missing
from the link command.

With this commit, it is now possible to install libgdal2 in a user
directory and compile ctb with this version. I tested on Ubuntu 14.10.

For example:
cmake -DGDAL_LIBRARY_DIR=/home/gberaudo/dev/inst/lib
-DGDAL_LIBRARY=/home/gberaudo/dev/inst/lib/libgdal.so
-DGDAL_INCLUDE_DIR=/home/gberaudo/dev/inst/include ..