### PR TITLE
Thread mutex on GDALTiler constructor

### DIFF
--- a/src/GDALTiler.cpp
+++ b/src/GDALTiler.cpp
@@ -22,6 +22,7 @@
 #include <cmath>                // std::abs
 #include <algorithm>            // std::minmax
 #include <string.h>             // strlen
+#include <mutex>
 
 #include "gdal_priv.h"
 #include "gdalwarper.h"
@@ -39,6 +40,11 @@ GDALTiler::GDALTiler(GDALDataset *poDataset, const Grid &grid, const TilerOption
   poDataset(poDataset),
   options(options)
 {
+
+  // Transformed bounds can give slightly different results on different threads unless mutexed
+  static std::mutex mutex;
+  std::lock_guard<std::mutex> lock(mutex);
+
   // if the dataset is set we need to initialise the tile bounds and raster
   // resolution from it.
   if (poDataset != NULL) {


### PR DESCRIPTION
On multithreading jobs the [transformed bounds](https://github.com/geo-data/cesium-terrain-builder/blob/master/src/GDALTiler.cpp#L101) can vary slightly between threads on some datasets.  This results in a lot of missing tiles and other issues as different threads can end up processing the same tile, while other tiles get skipped.  A mutex around the transform calculation seems sufficient to give the same bounds on each thread.

I'm assuming this is a GDAL issue.  gdalinfo --version indicates GDAL 2.0.1